### PR TITLE
Feature/implement 64 bit ints and vectorization

### DIFF
--- a/pyqvd/io/reader.py
+++ b/pyqvd/io/reader.py
@@ -156,6 +156,7 @@ class QvdFileReader:
         self._header.compression = header_xml.find("Compression").text
         self._header.record_byte_size = int(header_xml.find("RecordByteSize").text, 10)
         self._header.no_of_records = int(header_xml.find("NoOfRecords").text, 10)
+        self._header.no_of_fields = len(self._header.fields)
         self._header.offset = int(header_xml.find("Offset").text, 10)
         self._header.length = int(header_xml.find("Length").text, 10)
         self._header.comment = header_xml.find("Comment").text
@@ -184,7 +185,7 @@ class QvdFileReader:
         """
         self._read_symbol_table_data()
 
-        self._symbol_table = [None] * len(self._header.fields)
+        self._symbol_table = [None] * self._header.no_of_fields
 
         for field_index, field in enumerate(self._header.fields):
             symbols: List[QvdValue] = []

--- a/pyqvd/qvd.py
+++ b/pyqvd/qvd.py
@@ -2553,24 +2553,24 @@ class QvdTable:
 
             return QvdTable._get_symbol_from_value(value)
 
-        def _get_symbol_from_pandas_value_(row):
+        def _get_symbol_from_pandas_value_(column):
 
-            value_type = row.dtype
+            value_type = column.dtype
 
             if is_integer_dtype(value_type):
-                val_max = int(row.abs().max())
+                val_max = int(column.abs().max())
                 if is_int32(val_max):
-                    return row.apply(lambda x: IntegerValue(int(x)) if not pd.isna(x) else None)
+                    return column.apply(lambda x: IntegerValue(int(x)) if not pd.isna(x) else None)
                 else:
-                    return row.apply(lambda x: DualDoubleValue(float(x), str(x)) if not pd.isna(x) else None)
+                    return column.apply(lambda x: DualDoubleValue(float(x), str(x)) if not pd.isna(x) else None)
             if is_float_dtype(value_type):
-                return row.apply(lambda x: DoubleValue(float(x)) if not pd.isna(x) else None)
+                return column.apply(lambda x: DoubleValue(float(x)) if not pd.isna(x) else None)
             if is_datetime64_any_dtype(value_type):
-                return row.apply(lambda x: TimestampValue.from_timestamp(x.to_pydatetime()) if not pd.isna(x) else None)
+                return column.apply(lambda x: TimestampValue.from_timestamp(x.to_pydatetime()) if not pd.isna(x) else None)
             if is_timedelta64_dtype(value_type):
-                return row.apply(lambda x: IntervalValue.from_interval(x.to_pytimedelta()) if not pd.isna(x) else None)
+                return column.apply(lambda x: IntervalValue.from_interval(x.to_pytimedelta()) if not pd.isna(x) else None)
 
-            return row.apply(lambda x: QvdTable._get_symbol_from_value(x) if not pd.isna(x) else None)
+            return column.apply(lambda x: QvdTable._get_symbol_from_value(x) if not pd.isna(x) else None)
 
         if not vectorized:
             data = [[_get_symbol_from_pandas_value(value) for value in row] for row in df.values]

--- a/pyqvd/qvd.py
+++ b/pyqvd/qvd.py
@@ -2538,7 +2538,7 @@ class QvdTable:
             value_type = type(value)
 
             if is_integer_dtype(value_type):
-                if is_int32(value):
+                if is_int32(int(value)):
                     return IntegerValue(int(value))
                 else:
                     return DualDoubleValue(float(value), str(value))
@@ -2558,7 +2558,7 @@ class QvdTable:
             value_type = row.dtype
 
             if is_integer_dtype(value_type):
-                val_max = row.abs().max()
+                val_max = int(row.abs().max())
                 if is_int32(val_max):
                     return row.apply(lambda x: IntegerValue(int(x)) if not pd.isna(x) else None)
                 else:

--- a/pyqvd/qvd.py
+++ b/pyqvd/qvd.py
@@ -2501,7 +2501,7 @@ class QvdTable:
         return QvdTable(table_data, data["columns"])
 
     @staticmethod
-    def from_pandas(df: "pd.DataFrame", vectorized=False) -> "QvdTable":
+    def from_pandas(df: "pd.DataFrame", vectorized=True) -> "QvdTable":
         """
         Constructs a new QVD data table from a pandas data frame.
 

--- a/pyqvd/qvd.py
+++ b/pyqvd/qvd.py
@@ -2553,24 +2553,24 @@ class QvdTable:
 
             return QvdTable._get_symbol_from_value(value)
 
-        def _get_symbol_from_pandas_value_(column):
+        def _get_symbol_from_pandas_value_(row):
 
-            value_type = column.dtype
+            value_type = row.dtype
 
             if is_integer_dtype(value_type):
-                val_max = column.abs().max()
+                val_max = row.abs().max()
                 if is_int32(val_max):
-                    return column.apply(lambda x: IntegerValue(int(x)) if not pd.isna(x) else None)
+                    return row.apply(lambda x: IntegerValue(int(x)) if not pd.isna(x) else None)
                 else:
-                    return column.apply(lambda x: DualDoubleValue(float(x), str(x)) if not pd.isna(x) else None)
+                    return row.apply(lambda x: DualDoubleValue(float(x), str(x)) if not pd.isna(x) else None)
             if is_float_dtype(value_type):
-                return column.apply(lambda x: DoubleValue(float(x)) if not pd.isna(x) else None)
+                return row.apply(lambda x: DoubleValue(float(x)) if not pd.isna(x) else None)
             if is_datetime64_any_dtype(value_type):
-                return column.apply(lambda x: TimestampValue.from_timestamp(x.to_pydatetime()) if not pd.isna(x) else None)
+                return row.apply(lambda x: TimestampValue.from_timestamp(x.to_pydatetime()) if not pd.isna(x) else None)
             if is_timedelta64_dtype(value_type):
-                return column.apply(lambda x: IntervalValue.from_interval(x.to_pytimedelta()) if not pd.isna(x) else None)
+                return row.apply(lambda x: IntervalValue.from_interval(x.to_pytimedelta()) if not pd.isna(x) else None)
 
-            return column.apply(lambda x: QvdTable._get_symbol_from_value(x) if not pd.isna(x) else None)
+            return row.apply(lambda x: QvdTable._get_symbol_from_value(x) if not pd.isna(x) else None)
 
         if not vectorized:
             data = [[_get_symbol_from_pandas_value(value) for value in row] for row in df.values]

--- a/tests/qvd_test.py
+++ b/tests/qvd_test.py
@@ -381,7 +381,8 @@ def test_construct_qvd_table_from_pandas_df_vectorization_with_nones():
     tbl = QvdTable.from_pandas(raw_df, vectorized=True)
     tbl2 = QvdTable.from_pandas(raw_df, vectorized=False)
 
-    assert tbl2[2][0] is None
+    assert tbl[2][0] is None
+    assert tbl[1][2] is None
     assert tbl.__repr__() == tbl2.__repr__()
     assert_frame_equal(tbl.to_pandas(), tbl2.to_pandas())
 

--- a/tests/qvd_test.py
+++ b/tests/qvd_test.py
@@ -319,6 +319,9 @@ def test_construct_qvd_table_from_pandas_df_int64():
     assert tbl[1][0].calculation_value == largest_int32 + 2
     assert tbl[1][0].display_value == str(largest_int32 + 2)
 
+    # test previous edge case of native np.int64s
+    raw_df = pd.DataFrame([[largest_int32 + 1]], columns=['a'])
+    QvdTable.from_pandas(raw_df).to_stream(BytesIO())
 
 def test_construct_qvd_table_from_pandas_df_vectorization():
     """

--- a/tests/qvd_test.py
+++ b/tests/qvd_test.py
@@ -289,7 +289,7 @@ def test_construct_qvd_table_from_pandas_df():
 def test_construct_qvd_table_from_pandas_df_int64():
     """
     Tests if a QVD table, constructed from a pandas DataFrame containing 64-bit
-    integers, can be written to QVD file.
+    integers, contains DualDoubleValues and can be written to QVD file.
     """
     from io import BytesIO
     try:
@@ -312,7 +312,13 @@ def test_construct_qvd_table_from_pandas_df_int64():
                       dt.datetime(2021, 1, 5, 9, 0, 0)]
     })
 
-    QvdTable.from_pandas(raw_df).to_stream(BytesIO())
+    tbl = QvdTable.from_pandas(raw_df)
+
+    tbl.to_stream(BytesIO())
+    assert isinstance(tbl[1][0], DualDoubleValue)
+    assert tbl[1][0].calculation_value == largest_int32 + 2
+    assert tbl[1][0].display_value == str(largest_int32 + 2)
+
 
 def test_construct_qvd_table_from_pandas_df_vectorization():
     """
@@ -372,6 +378,7 @@ def test_construct_qvd_table_from_pandas_df_vectorization_with_nones():
     tbl = QvdTable.from_pandas(raw_df)
     tbl2 = QvdTable.from_pandas(raw_df, vectorized=False)
 
+    assert tbl2[2][0] is None
     assert tbl.__repr__() == tbl2.__repr__()
     assert_frame_equal(tbl.to_pandas(), tbl2.to_pandas())
 

--- a/tests/qvd_test.py
+++ b/tests/qvd_test.py
@@ -347,7 +347,7 @@ def test_construct_qvd_table_from_pandas_df_vectorization():
                       dt.datetime(2021, 1, 5, 9, 0, 0)]
     })
 
-    tbl = QvdTable.from_pandas(raw_df)
+    tbl = QvdTable.from_pandas(raw_df, vectorized=True)
     tbl2 = QvdTable.from_pandas(raw_df, vectorized=False)
 
     assert tbl.__repr__() == tbl2.__repr__()
@@ -378,7 +378,7 @@ def test_construct_qvd_table_from_pandas_df_vectorization_with_nones():
                       dt.datetime(2021, 1, 5, 9, 0, 0)]
     })
 
-    tbl = QvdTable.from_pandas(raw_df)
+    tbl = QvdTable.from_pandas(raw_df, vectorized=True)
     tbl2 = QvdTable.from_pandas(raw_df, vectorized=False)
 
     assert tbl2[2][0] is None


### PR DESCRIPTION
Enabled support for 64-bit integers via `DualDoubleValue`, addressing https://github.com/MuellerConstantin/PyQvd/issues/5.

Added vectorization to `.from_pandas()` method via optional argument `vectorized` (default `True`), resulting in around 3x speedup (probably scales with df/table length).

Removed redundant deepcopys from `writer.py` resulting in significant speedup for `.to_qvd()` (etc) methods (around 8x).

Added new tests for all the above. All previous tests still pass.